### PR TITLE
Add tests for pipe extension

### DIFF
--- a/Example/Ramda.xcodeproj/project.pbxproj
+++ b/Example/Ramda.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 607FACD91AFB9204008FA782 /* Main.storyboard */; };
 		607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
+		6337E48B1DA7F92800FD1B83 /* PipeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6337E48A1DA7F92800FD1B83 /* PipeTests.swift */; };
 		63B272401DA437A3008F3DC0 /* AnyPassTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B2723F1DA437A3008F3DC0 /* AnyPassTests.swift */; };
 		63FE4D571D8426C2001BDF4B /* AddIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63FE4D561D8426C2001BDF4B /* AddIndexTests.swift */; };
 		6C487A0A13683BE0EC3944E1 /* AllPassTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C487C732354FDF457157B7D /* AllPassTests.swift */; };
@@ -226,6 +227,7 @@
 		607FACDF1AFB9204008FA782 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
 		607FACE51AFB9204008FA782 /* Ramda_Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Ramda_Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACEA1AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		6337E48A1DA7F92800FD1B83 /* PipeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PipeTests.swift; sourceTree = "<group>"; };
 		63B2723F1DA437A3008F3DC0 /* AnyPassTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyPassTests.swift; sourceTree = "<group>"; };
 		63FE4D561D8426C2001BDF4B /* AddIndexTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddIndexTests.swift; sourceTree = "<group>"; };
 		6C487C732354FDF457157B7D /* AllPassTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AllPassTests.swift; sourceTree = "<group>"; };
@@ -356,6 +358,7 @@
 				34C0735DD7BF0108AD1A31FF /* TestTests.swift */,
 				34C07ACCFED39E6145F48804 /* FindTests.swift */,
 				63B2723F1DA437A3008F3DC0 /* AnyPassTests.swift */,
+				6337E48A1DA7F92800FD1B83 /* PipeTests.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -915,6 +918,7 @@
 				34C07FAC0EC9D75CDCDA54B7 /* EitherTests.swift in Sources */,
 				34C07402B188C3709047A1AB /* DropTests.swift in Sources */,
 				34C0743FB21BB03F139824C2 /* EmptyTests.swift in Sources */,
+				6337E48B1DA7F92800FD1B83 /* PipeTests.swift in Sources */,
 				34C070D76DA2F57DA544AEE4 /* EqualsTests.swift in Sources */,
 				34C07C6B1B891AEB4C88930A /* FilterTests.swift in Sources */,
 				34C076CF54CFC25D3DBFCDD6 /* GtTests.swift in Sources */,

--- a/Example/Tests/Extensions/PipeTests.swift
+++ b/Example/Tests/Extensions/PipeTests.swift
@@ -39,7 +39,7 @@ class PipeTests: XCTestCase {
 
     func testShouldPipeTwoFunctionsTogetherWithOptionalValueAndHaveOptionalResult() {
         let expectedResult = "4"
-        let element = R.find { R.modulo($0, by: 2) == 0 }
+        let element:(in: [Int]) -> Int? = R.find { R.modulo($0, by: 2) == 0 }
 
         let pipe: [Int] -> String = R.pipe(element, second: elementDescription)
         let result = pipe(testData)
@@ -48,7 +48,7 @@ class PipeTests: XCTestCase {
     }
 
     func testShouldPipeTwoFunctionsTogetherWithOptionalValueAndReturnsNil() {
-        let element = R.find { $0 < 0 }
+        let element:(in: [Int]) -> Int? = R.find { $0 < 0 }
 
         let pipe: [Int] -> String? = R.pipe(element, second: elementDescription)
         let result = pipe(testData)
@@ -67,7 +67,7 @@ class PipeTests: XCTestCase {
     }
 
     func testShouldPipeThreeFunctionsTogetherWithOptionalValueAndHaveOptionalResult() {
-        let element = R.find { R.modulo($0, by: 2) == 0 }
+        let element:(in: [Int]) -> Int? = R.find { R.modulo($0, by: 2) == 0 }
 
         let pipe: [Int] -> String = R.pipe(element, second: square, third: elementDescription)
         let result = pipe(testData)
@@ -76,7 +76,7 @@ class PipeTests: XCTestCase {
     }
 
     func testShouldPipeThreeFunctionsTogetherWithOptionalValueAndReturnsNil() {
-        let element = R.find { $0 < 0 }
+        let element:(in: [Int]) -> Int? = R.find { $0 < 0 }
 
         let pipe: [Int] -> String? = R.pipe(element, second: square, third: elementDescription)
         let result = pipe(testData)

--- a/Example/Tests/Extensions/PipeTests.swift
+++ b/Example/Tests/Extensions/PipeTests.swift
@@ -1,0 +1,113 @@
+//
+//  PipeTests.swift
+//  Ramda
+//
+//  Created by TYRONE AVNIT on 2016/10/07.
+//  Copyright © 2016 CocoaPods. All rights reserved.
+//
+
+import XCTest
+import Ramda
+
+class PipeTests: XCTestCase {
+
+    let testData = [67, 83, 4, 99, 22, 18, 21, 24, 23, 2, 86]
+
+    let elementDescription = { (element: Int) -> String in element.description }
+
+    func isEven(number: Int) -> Bool {
+        return number % 2 == 0
+    }
+
+    func increment(number: Int) -> Int {
+        return number + 1
+    }
+
+    func square(number: Int) -> Int {
+        return number * number
+    }
+
+    func testShouldPipeTwoFunctionsTogether() {
+        let expectedResult = 4
+        let input = 1
+
+        let pipe = R.pipe(increment, second: square)
+        let result = pipe(input)
+
+        XCTAssertEqual(expectedResult, result)
+    }
+
+    func testShouldPipeTwoFunctionsTogetherWithOptionalValueAndHaveOptionalResult() {
+        let expectedResult = "4"
+        let element = R.find { R.modulo($0, by: 2) == 0 }
+
+        let pipe: [Int] -> String = R.pipe(element, second: elementDescription)
+        let result = pipe(testData)
+
+        XCTAssertEqual(result, expectedResult)
+    }
+
+    func testShouldPipeTwoFunctionsTogetherWithOptionalValueAndReturnsNil() {
+        let element = R.find { $0 < 0 }
+
+        let pipe: [Int] -> String? = R.pipe(element, second: elementDescription)
+        let result = pipe(testData)
+
+        XCTAssertNil(result)
+    }
+
+    func testShouldPipeThreeFunctionsTogether() {
+        let expectedResult = 16
+        let input = 1
+
+        let pipe = R.pipe(increment, second: square, third: square)
+        let result = pipe(input)
+
+        XCTAssertEqual(expectedResult, result)
+    }
+
+    func testShouldPipeThreeFunctionsTogetherWithOptionalValueAndHaveOptionalResult() {
+        let element = R.find { R.modulo($0, by: 2) == 0 }
+
+        let pipe: [Int] -> String = R.pipe(element, second: square, third: elementDescription)
+        let result = pipe(testData)
+
+        XCTAssertEqual(result, "16")
+    }
+
+    func testShouldPipeThreeFunctionsTogetherWithOptionalValueAndReturnsNil() {
+        let element = R.find { $0 < 0 }
+
+        let pipe: [Int] -> String? = R.pipe(element, second: square, third: elementDescription)
+        let result = pipe(testData)
+
+        XCTAssertNil(result)
+    }
+
+    func testPipeOperatorShouldPipeMultipleFunctions() {
+        let pipe = testData
+            |> R.filter(isEven)
+            |> R.sort { $0 > $1 }
+            |> R.map { $0.description }
+
+        let result = pipe.joinWithSeparator("-")
+
+        XCTAssertEqual(result, "86-24-22-18-4-2")
+    }
+
+    func testShouldPipeTwoFunctionsTogetherWithOptionalValueAndReturnUnwrappedValue() {
+        let result = testData
+            |> R.find { $0 > 0 }
+            |>! { $0.description }
+
+        XCTAssertNotNil(result)
+    }
+
+    func testShouldPipeTwoFunctionsTogetherWithOptionalValueAndReturnOptionalValue() {
+        let result = testData
+            |> R.find { $0 < 0 }
+            |>? { $0.description }
+
+        XCTAssertNil(result)
+    }
+}

--- a/Ramda/Extensions/find.swift
+++ b/Ramda/Extensions/find.swift
@@ -7,7 +7,7 @@ import Foundation
 // swiftlint:disable line_length
 
 extension R {
-    
+
     /**
      Returns the first element of the list which matches the predicate,
      or nil if no element matches.
@@ -15,7 +15,7 @@ extension R {
      - parameter sequence: The sequence to check.
      - returns: The first found element, or nil if none found.
      */
-    
+
     public class func find<A, B: SequenceType where A == B.Generator.Element>(predicate: (A) -> Bool, in sequence: B) -> A? {
         for element in sequence {
             if predicate(element) {
@@ -24,7 +24,7 @@ extension R {
         }
         return nil
     }
-    
+
     /**
      Returns the first element of the list which matches the predicate,
      or nil if no element matches.
@@ -32,9 +32,9 @@ extension R {
      - returns: A curried function that accepts a sequence and returns
      the first found element, or nil if none found.
      */
-    
+
     public class func find<A, B: SequenceType where A == B.Generator.Element>(predicate: (A) -> Bool) -> (in: B) -> A? {
         return curry(find)(predicate)
     }
-    
+
 }

--- a/Ramda/Extensions/find.swift
+++ b/Ramda/Extensions/find.swift
@@ -20,7 +20,7 @@ extension R {
 
     */
 
-    public class func find<A, B: SequenceType where A == B.Generator.Element>(predicate: (A) -> Bool, in sequence: B) -> A? {
+    private class func find<A>(predicate: (A) -> Bool, in sequence: [A]) -> A? {
         for element in sequence {
             if predicate(element) {
                 return element
@@ -41,7 +41,7 @@ extension R {
 
     */
 
-    public class func find<A, B: SequenceType where A == B.Generator.Element>(predicate: (A) -> Bool) -> (in: B) -> A? {
+    public class func find<A>(predicate: (A) -> Bool) -> (in: [A]) -> A? {
         return curry(find)(predicate)
     }
 

--- a/Ramda/Extensions/find.swift
+++ b/Ramda/Extensions/find.swift
@@ -7,20 +7,16 @@ import Foundation
 // swiftlint:disable line_length
 
 extension R {
-
+    
     /**
-
-        Returns the first element of the list which matches the predicate,
-        or nil if no element matches.
-
-        - parameter predicate: The function that returns a bool.
-        - parameter sequence: The sequence to check.
-
-        - returns: The first found element, or nil if none found.
-
-    */
-
-    private class func find<A>(predicate: (A) -> Bool, in sequence: [A]) -> A? {
+     Returns the first element of the list which matches the predicate,
+     or nil if no element matches.
+     - parameter predicate: The function that returns a bool.
+     - parameter sequence: The sequence to check.
+     - returns: The first found element, or nil if none found.
+     */
+    
+    public class func find<A, B: SequenceType where A == B.Generator.Element>(predicate: (A) -> Bool, in sequence: B) -> A? {
         for element in sequence {
             if predicate(element) {
                 return element
@@ -28,23 +24,17 @@ extension R {
         }
         return nil
     }
-
+    
     /**
-
-        Returns the first element of the list which matches the predicate,
-        or nil if no element matches.
-
-        - parameter predicate: The function that returns a bool.
-
-        - returns: A curried function that accepts a sequence and returns
-        the first found element, or nil if none found.
-
-    */
-
-    public class func find<A>(predicate: (A) -> Bool) -> (in: [A]) -> A? {
+     Returns the first element of the list which matches the predicate,
+     or nil if no element matches.
+     - parameter predicate: The function that returns a bool.
+     - returns: A curried function that accepts a sequence and returns
+     the first found element, or nil if none found.
+     */
+    
+    public class func find<A, B: SequenceType where A == B.Generator.Element>(predicate: (A) -> Bool) -> (in: B) -> A? {
         return curry(find)(predicate)
     }
-
+    
 }
-
-// swiftlint:enable line_length


### PR DESCRIPTION
@JustinGuedes I had to change the signature of find to take an array as opposed to a sequence type. I just could not get find to work as a curried function otherwise. Check pipe tests for an example. Maybe I am doing something wrong. Coverage will also be down until this is merged in.

<img width="901" alt="screen shot 2016-10-08 at 11 23 50 am" src="https://cloud.githubusercontent.com/assets/1284501/19212055/f2c2b24c-8d49-11e6-86a5-486709651e31.png">
<img width="899" alt="screen shot 2016-10-08 at 11 24 01 am" src="https://cloud.githubusercontent.com/assets/1284501/19212056/f2c3a026-8d49-11e6-95d6-2b16659496e7.png">
